### PR TITLE
AWS Assume Role script improvements

### DIFF
--- a/aws-cli-assumerole.sh
+++ b/aws-cli-assumerole.sh
@@ -1,28 +1,47 @@
 #! /bin/bash
 #
 # Dependencies:
-#   brew install jq
+#   MacOS : brew install jq
+#   Linux (deb based) : apt install jq
 #
 # Setup:
 #   chmod +x ./aws-cli-assumerole.sh
 #
 # Execute:
-#   source ./aws-cli-assumerole.sh
+#   source ./aws-cli-assumerole.sh <AWS_ID> [<AWS_ROLE> [<SESSION_NAME>]]
 #
 # Description:
 #   Makes assuming an AWS IAM role (+ exporting new temp keys) easier
 
-unset  AWS_SESSION_TOKEN
-export AWS_ACCESS_KEY_ID=<user_access_key>
-export AWS_SECRET_ACCESS_KEY=<user_secret_key>
-export AWS_REGION=eu-west-1
+AWS_PROFILE="default"
+AWS_ROLE="OrganizationAccountAccessRole"
 
-temp_role=$(aws sts assume-role \
-                    --role-arn "arn:aws:iam::<aws_account_number>:role/<role_name>" \
-                    --role-session-name "<some_session_name>")
+if [ $# -eq 0 ] || [ $# -gt 3 ]; then
+  echo "Usage : $0 <AWS_ID> [<AWS_ROLE> <SESSION_NAME>]"
+else
+  if [ ! -z "$2" ]; then
+    AWS_ROLE=$2
+  fi
+  if [ ! -z "$3" ]; then
+    AWS_SESSION_NAME=$3
+  else
+    AWS_SESSION_NAME="Assume-$1"
+  fi
 
-export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
-export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
-export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+  unset  AWS_SESSION_TOKEN
+  export AWS_ACCESS_KEY_ID=$(grep -A2 "\[$AWS_PROFILE\]" ~/.aws/credentials | awk -F"= " '/aws_access_key_id/ {print $2}')
+  export AWS_SECRET_ACCESS_KEY=$(grep -A2 "\[$AWS_PROFILE\]" ~/.aws/credentials | awk -F"= " '/aws_secret_access_key/ {print $2}')
+  export AWS_REGION=$(grep -A2 "\[$AWS_PROFILE\]" ~/.aws/config | awk -F"= " '/region/ {print $2}')
 
-env | grep -i AWS_
+  TEMP_ROLE=$(aws sts assume-role \
+                    --role-arn "arn:aws:iam::$1:role/$AWS_ROLE" \
+                    --role-session-name "$AWS_SESSION_NAME")
+
+  echo "Assumed ARN : $(echo $TEMP_ROLE | jq .AssumedRoleUser.Arn | xargs)"
+
+  export AWS_ACCESS_KEY_ID=$(echo $TEMP_ROLE | jq .Credentials.AccessKeyId | xargs)
+  export AWS_SECRET_ACCESS_KEY=$(echo $TEMP_ROLE | jq .Credentials.SecretAccessKey | xargs)
+  export AWS_SESSION_TOKEN=$(echo $TEMP_ROLE | jq .Credentials.SessionToken | xargs)
+
+  env | grep -i AWS_
+fi


### PR DESCRIPTION
- Make the script more modular no need to hardcode value anymore
- Get the user's AWS CLI credentials
- Ability to choose from different AWS profile (could be easily added as a parameter with getopts but didn't wanted to spend too much time on this)